### PR TITLE
Add a note about ansible_port and add full path to parted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Requirements
 
 * Requires `raspi-config` to be installed. (It's installed by default on Raspbian.)
 
-* `ansible_port` must be set inside inventory file.
+* `ansible_port` must be set inside inventory file. Inventory example:
+```
+# For initial setup of Raspbian
+pi ansible_host=192.168.0.100 ansible_user=pi ansible_ssh_pass=raspberry ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_port=22
+```
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Notes
 
 * This role internally uses `raspi-config` to expand the root filesystem, so the behaviour is the same as running that tool. For example, the operation is non-destructive.
 
-* `ansible_port` must be set inside inventory file.
-
 * This role currently tests for the existence of the file `/var/ansible/fs_expanded` to determine if the filesystem has already been expanded or not.
 
   If you've already manually expanded the filesystem and then run this role anyway, the first time the role runs it will still go through the process of expanding the filesystem,
@@ -20,7 +18,9 @@ Notes
 Requirements
 ------------
 
-Requires `raspi-config` to be installed. (It's installed by default on Raspbian.)
+* Requires `raspi-config` to be installed. (It's installed by default on Raspbian.)
+
+* `ansible_port` must be set inside inventory file.
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Notes
 
 * This role internally uses `raspi-config` to expand the root filesystem, so the behaviour is the same as running that tool. For example, the operation is non-destructive.
 
+* `ansible_port` must be set inside inventory file.
+
 * This role currently tests for the existence of the file `/var/ansible/fs_expanded` to determine if the filesystem has already been expanded or not.
 
   If you've already manually expanded the filesystem and then run this role anyway, the first time the role runs it will still go through the process of expanding the filesystem,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check unpartitioned space
-  shell: parted /dev/mmcblk0 unit gb print free | grep 'Free Space' | tail -n1 | awk '{print $3}'
+  shell: /sbin/parted /dev/mmcblk0 unit gb print free | grep 'Free Space' | tail -n1 | awk '{print $3}'
   register: unpartitioned
   changed_when: false
 


### PR DESCRIPTION
Restart handler fails w/o `ansible_port` set inside inventory. Added a note about this.
Parted fails on a fresh copy of Raspbian. This fixes it.